### PR TITLE
chore(42L-923): custom domain ff3-entropy.42labs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ![FF3 Entropy — Outstanding view showing an overdue backlog, a needs-review item, and income/expense totals](docs/forecast.png)
 
-**Live demo (100% synthetic data — no Firefly III instance behind it):**
-[4242labs.github.io/ff3-entropy](https://4242labs.github.io/ff3-entropy/) — goes live once GitHub Pages
-is enabled for this repo; until then that link 404s.
+**[Live demo →](https://ff3-entropy.42labs.io)** — 100% synthetic data, no Firefly III instance behind it.
 
 **What's coming, and whether it actually happened.**
 

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+ff3-entropy.42labs.io


### PR DESCRIPTION
Points the public demo at **https://ff3-entropy.42labs.io**.

- Adds `web/public/CNAME` (Vite copies it to `dist/CNAME`) so the Pages custom domain persists across every Actions deploy.
- Updates the README demo link.

DNS: `ff3-entropy.42labs.io` CNAME → `4242labs.github.io` (Cloudflare, DNS-only so GitHub provisions HTTPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)