### PR TITLE
chore: rename to Entropy for Firefly III (ff3e)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 FIREFLY_III_URL=https://firefly.example.com
 
 # Firefly III → Options → Profile → OAuth → Personal Access Tokens → Create.
-# Read-only is all FF3 Entropy ever does with it.
+# Read-only is all Entropy for Firefly III ever does with it.
 FIREFLY_III_TOKEN=
 
 # How many days either side of an expected date still counts as "that's the one"

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -2,13 +2,13 @@
 
 Copyright (c) 2026 42labs.
 
-FF3 Entropy is dual-licensed.
+Entropy for Firefly III is dual-licensed.
 
 1. **Open source** — [GNU Affero General Public License v3.0](LICENSE) (AGPL-3.0).
    Use it, run it, modify it, self-host it. If you run a modified version as a
    network service, the AGPL requires you to offer your users its source.
 
-2. **Commercial** — to use FF3 Entropy without the obligations of the AGPL-3.0
+2. **Commercial** — to use Entropy for Firefly III without the obligations of the AGPL-3.0
    (for example, in a closed-source or SaaS context), a commercial license is
    available. Contact <ahoy@42labs.io>.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# FF3 Entropy
+# Entropy for Firefly III
 
-![FF3 Entropy — Outstanding view showing an overdue backlog, a needs-review item, and income/expense totals](docs/forecast.png)
+![Entropy for Firefly III — Outstanding view showing an overdue backlog, a needs-review item, and income/expense totals](docs/forecast.png)
 
-**[Live demo →](https://ff3-entropy.42labs.io)** — 100% synthetic data, no Firefly III instance behind it.
+**[Live demo →](https://ff3e.42labs.io)** — 100% synthetic data, no Firefly III instance behind it.
 
 **What's coming, and whether it actually happened.**
 
@@ -10,7 +10,7 @@ Firefly III knows all your recurring transactions — rent, salary, that streami
 subscription. But it won't lay them out in front of you and tell you which ones
 have already landed and which are quietly overdue.
 
-FF3 Entropy does exactly that, and nothing else. It's a read-only **Forecast**
+Entropy for Firefly III does exactly that, and nothing else. It's a read-only **Forecast**
 view: point it at your Firefly III, and it projects every recurring transaction
 forward, then matches each expected occurrence against your real booked
 transactions.
@@ -25,7 +25,7 @@ Every occurrence ends up in one of five states:
 | **Done** | A transfer that went through. |
 | **Needs review** | Its date has passed and no matching transaction turned up. |
 
-That last one is the point of the whole thing. FF3 Entropy never guesses: if it
+That last one is the point of the whole thing. Entropy for Firefly III never guesses: if it
 can't find a real transaction with the same type, the same exact amount, on the
 same account, within a few days of the expected date, it says so instead of
 pretending.
@@ -45,8 +45,8 @@ You need a Firefly III instance and a Personal Access Token
 (*Options → Profile → OAuth → Personal Access Tokens*).
 
 ```bash
-git clone https://github.com/4242labs/ff3-entropy.git
-cd ff3-entropy
+git clone https://github.com/4242labs/ff3e.git
+cd ff3e
 cp .env.example .env      # add your FIREFLY_III_URL and FIREFLY_III_TOKEN
 docker compose up
 ```
@@ -56,13 +56,13 @@ Then open <http://localhost:8000>.
 ## How it fits together
 
 ```
-browser ──▶ FF3 Entropy server ──▶ Firefly III REST API
-  (SPA)      (forecast engine)        (your data, untouched)
+browser ──▶ Entropy server ──▶ Firefly III REST API
+  (SPA)     (forecast engine)   (your data, untouched)
 ```
 
 The server exists for one reason: Firefly III authenticates with a token that
 must never live in browser code, and it doesn't send CORS headers — so the
-browser can't call it directly. FF3 Entropy's server holds the token, reads, and
+browser can't call it directly. The Entropy server holds the token, reads, and
 hands back JSON. **It writes nothing back to Firefly III.** Your recurring
 transactions can stay paused; they'll never auto-post because of this.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  ff3-entropy:
+  ff3e:
     build: .
-    image: ff3-entropy
+    image: ff3e
     ports:
       - "${PORT:-8000}:8000"
     environment:

--- a/server/forecast.py
+++ b/server/forecast.py
@@ -20,12 +20,12 @@ from typing import Optional
 
 import httpx
 
-log = logging.getLogger("ff3-entropy.forecast")
+log = logging.getLogger("ff3e.forecast")
 
 FIREFLY_III_URL = os.environ.get("FIREFLY_III_URL", "").rstrip("/")
 FIREFLY_III_TOKEN = os.environ.get("FIREFLY_III_TOKEN", "")
 MATCH_DAYS = int(os.environ.get("MATCH_DAYS", "5"))  # ± window for a match
-_UA = "ff3-entropy/1.0"
+_UA = "ff3e/1.0"
 _TIMEOUT = httpx.Timeout(30.0)
 
 # direction → (status-when-matched, sign) ; sign is for out/in aggregation

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,4 @@
-"""FF3 Entropy — HTTP server.
+"""Entropy for Firefly III — HTTP server.
 
 Two jobs, and no more:
 
@@ -27,9 +27,9 @@ from fastapi.staticfiles import StaticFiles
 import forecast
 
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
-log = logging.getLogger("ff3-entropy")
+log = logging.getLogger("ff3e")
 
-app = FastAPI(title="FF3 Entropy", docs_url=None, redoc_url=None)
+app = FastAPI(title="Entropy for Firefly III", docs_url=None, redoc_url=None)
 
 
 def _parse_date(s: Optional[str]) -> Optional[dt.date]:

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="./favicon-192x192.png" />
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
-    <title>FF3 Entropy | 42labs</title>
+    <title>Entropy for Firefly III | 42labs</title>
     <meta
       name="description"
       content="A read-only forecast view for Firefly III. It projects every recurring transaction forward and matches each one against your real booked transactions, so you can see what's landed and what's quietly overdue."
@@ -21,19 +21,19 @@
          blank card without these. og:image must be absolute, so it is pinned to the
          demo's own domain rather than the relative base the icons use. -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="FF3 Entropy" />
-    <meta property="og:title" content="FF3 Entropy — what's coming, and whether it actually happened" />
+    <meta property="og:site_name" content="Entropy for Firefly III" />
+    <meta property="og:title" content="Entropy for Firefly III — what's coming, and whether it actually happened" />
     <meta
       property="og:description"
       content="A read-only forecast view for Firefly III. Projects your recurring transactions forward, matches them against what really got booked, and flags the ones that never turned up."
     />
-    <meta property="og:url" content="https://ff3-entropy.42labs.io/" />
-    <meta property="og:image" content="https://ff3-entropy.42labs.io/og.png" />
+    <meta property="og:url" content="https://ff3e.42labs.io/" />
+    <meta property="og:image" content="https://ff3e.42labs.io/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="The FF3 Entropy forecast view: income and expense totals, an out-by-category chart, and a table row flagged Needs review."
+      content="The Entropy for Firefly III forecast view: income and expense totals, an out-by-category chart, and a table row flagged Needs review."
     />
     <meta name="twitter:card" content="summary_large_image" />
   </head>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ff3-entropy-web",
+  "name": "ff3e-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ff3-entropy-web",
+      "name": "ff3e-web",
       "version": "0.1.0",
       "dependencies": {
         "@fontsource/geist-mono": "^5.2.8",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ff3-entropy-web",
+  "name": "ff3e-web",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,1 +1,1 @@
-ff3-entropy.42labs.io
+ff3e.42labs.io

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -23,7 +23,7 @@ interface NavItem {
   icon: ComponentType<{ className?: string }>
 }
 
-// One entry per view. FF3 Entropy ships a single view today (Forecast); adding
+// One entry per view. Entropy for Firefly III ships a single view today (Forecast); adding
 // another later is a new row here (+ a router when there's more than one).
 const NAV: NavItem[] = [{ key: 'forecast', label: 'Forecast', icon: CalendarClock }]
 
@@ -45,7 +45,7 @@ export function AppSidebar({ activeView = 'forecast' }: { activeView?: string })
           href="https://42labs.io"
           target="_blank"
           rel="noreferrer"
-          aria-label="FF3 Entropy — by 42labs"
+          aria-label="Entropy for Firefly III — by 42labs"
           className="my-[12px] flex flex-row items-center justify-center gap-[8px] outline-none transition-opacity hover:opacity-80 focus-visible:opacity-80 group-data-[collapsible=icon]:m-0"
         >
           <BrandMark className="h-[42px] w-[42px] shrink-0 text-[var(--logo)] group-data-[collapsible=icon]:h-[26px] group-data-[collapsible=icon]:w-[26px]" />
@@ -80,7 +80,7 @@ export function AppSidebar({ activeView = 'forecast' }: { activeView?: string })
         {/* Row 1 — licence + source, icons only */}
         <div className="flex items-center justify-center gap-[16px]">
           <a
-            href="https://github.com/4242labs/ff3-entropy/blob/main/LICENSE"
+            href="https://github.com/4242labs/ff3e/blob/main/LICENSE"
             target="_blank"
             rel="noreferrer"
             aria-label="AGPL-3.0 licence"
@@ -90,7 +90,7 @@ export function AppSidebar({ activeView = 'forecast' }: { activeView?: string })
             <img src="opensource.svg" alt="AGPL-3.0 licence" className="h-[24px] w-[24px]" />
           </a>
           <a
-            href="https://github.com/4242labs/ff3-entropy"
+            href="https://github.com/4242labs/ff3e"
             target="_blank"
             rel="noreferrer"
             aria-label="Source on GitHub"

--- a/web/src/components/Wordmark.tsx
+++ b/web/src/components/Wordmark.tsx
@@ -15,7 +15,7 @@ export function Wordmark({ className }: { className?: string }) {
       viewBox="0 0 219 70"
       fill="currentColor"
       role="img"
-      aria-label="FF3 Entropy"
+      aria-label="Entropy for Firefly III"
       xmlns="http://www.w3.org/2000/svg"
     >
       <text


### PR DESCRIPTION
Renames the product everywhere the name appears explicitly.

- **Prose name:** FF3 Entropy → **Entropy for Firefly III** (README, LICENSING, `.env.example`, page metadata, sidebar/wordmark `aria-label`, FastAPI title).
- **Logo:** the `FF3E` glyphs in `Wordmark.tsx` are unchanged — only the accessible description moves.
- **Identifiers:** `ff3-entropy` → `ff3e` — repo URLs, npm package (`ff3e-web`), compose service + image, Python loggers and user-agent.
- **Domain:** `web/public/CNAME` → `ff3e.42labs.io`. DNS is cut over separately; the old host redirects.

Validation: `npm run build` clean, `py_compile` clean on both server modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)