### PR TITLE
ci: add LGTM security gate

### DIFF
--- a/.github/workflows/lgtm.yml
+++ b/.github/workflows/lgtm.yml
@@ -1,0 +1,8 @@
+name: LGTM
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  gate:
+    uses: 4242labs/lgtm/.github/workflows/gate.yml@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,10 @@ COPY server/ ./
 COPY --from=web /web/dist ./web/dist
 ENV WEB_DIST=/app/web/dist
 
+# Run as an unprivileged user (container must not run as root).
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Adds the fleet-wide LGTM code-security gate (deps/secrets/sast) on pull_request. References 4242labs/lgtm/.github/workflows/gate.yml@main. Advisory until branch protection lands (42L-999).