### PR TITLE
feat(filter): "Account" facet lists asset accounts only ("Asset Account")

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ pretending.
 - **Outstanding** — everything unconfirmed and already due, including the months
   behind you.
 - **Due by Month-End** — the same, plus what's still ahead this month.
-- Filter by type, category, account or currency; totals never cross-sum
-  currencies.
+- Filter by type, category, **asset account** or currency; totals never
+  cross-sum currencies. (The account facet lists only your own asset accounts —
+  the paying/receiving side — never expense or revenue counterparties.)
 
 ## Run it
 

--- a/server/forecast.py
+++ b/server/forecast.py
@@ -272,8 +272,15 @@ def build_projection(granularity: str = "month",
             amt = abs(float(tx.get("amount") or 0))
             if category and cat != category:
                 continue
-            if account and account not in (src, dst):
-                continue
+            # The account facet filters on the OWN (asset) side only — a
+            # withdrawal's source, a deposit's destination, both ends of a
+            # transfer (Firefly's account-type invariant). This keeps expense
+            # (payee) / revenue (payer) names out of the "Asset Account" filter.
+            if account:
+                own = (src,) if rtype == "withdrawal" else \
+                      (dst,) if rtype == "deposit" else (src, dst)
+                if account not in own:
+                    continue
             if currency and cur != currency:
                 continue
             for d in occ_dates:

--- a/web/src/components/CategoryPie.tsx
+++ b/web/src/components/CategoryPie.tsx
@@ -14,8 +14,8 @@ function groupKey(item: ProjectionItem, groupBy: PieGroupBy): string {
     case 'category':
       return item.category ?? 'Uncategorised'
     case 'account':
-      // For an expense (withdrawal), `source` is the paying asset account —
-      // the meaningful breakdown when categories are unset.
+      // The pie only ever sums withdrawals, so `source` is always the paying
+      // asset account — the meaningful breakdown when categories are unset.
       return item.source ?? 'Uncategorised'
     case 'payee':
       return item.title || 'Uncategorised'
@@ -98,7 +98,7 @@ export function CategoryPie({ periods, availableCurrencies }: CategoryPieProps) 
           <Tabs value={groupBy} onValueChange={(v) => setGroupBy(v as PieGroupBy)}>
             <TabsList>
               <TabsTrigger value="category">Category</TabsTrigger>
-              <TabsTrigger value="account">Account</TabsTrigger>
+              <TabsTrigger value="account">Asset Account</TabsTrigger>
               <TabsTrigger value="payee">Payee</TabsTrigger>
             </TabsList>
           </Tabs>

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -39,7 +39,7 @@ export function FilterBar({ options, filters, onChange }: FilterBarProps) {
         onChange={(v) => set('category', v)}
       />
       <FacetedFilter
-        title="Account"
+        title="Asset Account"
         options={options.accounts.map((a) => ({ value: a, label: a }))}
         selected={filters.account}
         onChange={(v) => set('account', v)}

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -33,6 +33,25 @@ export interface FilterOptions {
   currencies: string[]
 }
 
+/** The user's OWN account(s) on an item — the "asset" side, keyed off
+ * direction. Firefly guarantees: a withdrawal's SOURCE, a deposit's
+ * DESTINATION, and BOTH ends of a transfer are asset/liability (own)
+ * accounts; the opposite end is an expense (payee) or revenue (payer)
+ * account. The "Asset Account" facet lists and matches on these only, so
+ * vendor/payee names never pollute the account dropdown. */
+export function assetAccountsOf(
+  item: Pick<ProjectionItem, 'type' | 'source' | 'destination'>,
+): string[] {
+  switch (item.type) {
+    case 'withdrawal':
+      return item.source ? [item.source] : []
+    case 'deposit':
+      return item.destination ? [item.destination] : []
+    case 'transfer':
+      return [item.source, item.destination].filter((a): a is string => a !== null)
+  }
+}
+
 /** Union of values present, computed over the UNFILTERED dataset —
  * this is what populates the filter dropdowns, and must not shrink as the
  * user narrows other filters (avoids the "option collapse" trap). */
@@ -48,8 +67,7 @@ export function getFilterOptions(data: ProjectionsResponse): FilterOptions {
       types.add(it.type)
       if (it.category) categories.add(it.category)
       else hasUncategorised = true
-      if (it.source) accounts.add(it.source)
-      if (it.destination) accounts.add(it.destination)
+      for (const a of assetAccountsOf(it)) accounts.add(a)
       if (it.currency) currencies.add(it.currency)
     }
   }
@@ -80,9 +98,8 @@ export function itemMatchesFilters(item: ProjectionItem, filters: ActiveFilters)
   }
 
   if (filters.account.length) {
-    const hit =
-      (item.source !== null && filters.account.includes(item.source)) ||
-      (item.destination !== null && filters.account.includes(item.destination))
+    // Match on the OWN (asset) side only — see assetAccountsOf.
+    const hit = assetAccountsOf(item).some((a) => filters.account.includes(a))
     if (!hit) return false
   }
 


### PR DESCRIPTION
## What

The forecast's account facet listed **both** ends of every item, so expense (payee) and revenue (payer) counterparties polluted the "Account" dropdown alongside the user's real accounts.

Now the facet **lists and matches the OWN (asset) side only**, keyed off direction — a withdrawal's `source`, a deposit's `destination`, both ends of a transfer (Firefly's account-type invariant). The facet and the pie group-by tab are relabelled **"Asset Account"**.

## How

- New `assetAccountsOf(item)` helper in `lib/filters.ts` — single source of the "own side" rule.
- `getFilterOptions` builds the account options from it; `itemMatchesFilters` matches on it.
- `server/forecast.py` — the server-side `account` param mirrors the same asset-side semantics.
- No new Firefly API call: the asset side is derivable purely from data already in each projection item.

## Notes

- Pure display/facet change — the **matcher** (exact type + amount + source/destination pair) is untouched.
- Builds clean (`tsc --noEmit && vite build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)