### PR TITLE
feat(config): make the deployment consumable via env/build flags (#921)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,16 @@ FIREFLY_III_TOKEN=
 # when matching a real transaction to a projected occurrence.
 MATCH_DAYS=5
 
+# Optional — only if your Firefly III sits behind a Cloudflare Access service
+# auth. Both must be set to take effect; unset means no such headers are sent.
+FIREFLY_CF_ACCESS_CLIENT_ID=
+FIREFLY_CF_ACCESS_CLIENT_SECRET=
+
 # Host port to serve on.
 PORT=8000
+
+# --- Web build-time flags (set when running `npm run build` in web/) ---
+# VITE_BASE        public base path when the SPA is mounted under a subpath
+#                  (default: ./). e.g. /entropy/
+# VITE_API_BASE    forecast endpoint the SPA calls (default: api/forecast).
+# VITE_AUTH_RELOAD 1 to reload on an expired auth-proxy session (default: off).

--- a/server/forecast.py
+++ b/server/forecast.py
@@ -25,8 +25,21 @@ log = logging.getLogger("ff3e.forecast")
 FIREFLY_III_URL = os.environ.get("FIREFLY_III_URL", "").rstrip("/")
 FIREFLY_III_TOKEN = os.environ.get("FIREFLY_III_TOKEN", "")
 MATCH_DAYS = int(os.environ.get("MATCH_DAYS", "5"))  # ± window for a match
+# Optional: when Firefly III sits behind a Cloudflare Access service auth, these
+# add the service-token headers to every request. Unset → not sent (the common
+# case: a directly reachable Firefly III).
+FIREFLY_CF_ACCESS_CLIENT_ID = os.environ.get("FIREFLY_CF_ACCESS_CLIENT_ID", "")
+FIREFLY_CF_ACCESS_CLIENT_SECRET = os.environ.get("FIREFLY_CF_ACCESS_CLIENT_SECRET", "")
 _UA = "ff3e/1.0"
 _TIMEOUT = httpx.Timeout(30.0)
+
+
+def _access_headers() -> dict:
+    """Cloudflare Access service-token headers, only when both are configured."""
+    if FIREFLY_CF_ACCESS_CLIENT_ID and FIREFLY_CF_ACCESS_CLIENT_SECRET:
+        return {"CF-Access-Client-Id": FIREFLY_CF_ACCESS_CLIENT_ID,
+                "CF-Access-Client-Secret": FIREFLY_CF_ACCESS_CLIENT_SECRET}
+    return {}
 
 # direction → (status-when-matched, sign) ; sign is for out/in aggregation
 _DIR = {
@@ -52,7 +65,8 @@ def _get(path: str, params: Optional[dict] = None) -> dict:
     r = httpx.get(
         f"{FIREFLY_III_URL}{path}", params=params,
         headers={"Authorization": f"Bearer {FIREFLY_III_TOKEN}",
-                 "Accept": "application/json", "User-Agent": _UA},
+                 "Accept": "application/json", "User-Agent": _UA,
+                 **_access_headers()},
         timeout=_TIMEOUT,
     )
     r.raise_for_status()

--- a/web/src/hooks/useProjections.ts
+++ b/web/src/hooks/useProjections.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { fetchForecast } from '@/lib/api'
+import { AuthExpiredError, fetchForecast } from '@/lib/api'
 import type { ProjectionsResponse } from '@/lib/types'
 
 interface Query {
@@ -30,6 +30,13 @@ export function useProjections(query: Query) {
       })
       .catch((err) => {
         if (cancelled) return
+        // Under VITE_AUTH_RELOAD, an expired auth-proxy session reloads the
+        // page (bouncing through the login) instead of surfacing a retryable
+        // error. Never thrown when the flag is off, so this is inert by default.
+        if (err instanceof AuthExpiredError) {
+          window.location.reload()
+          return
+        }
         // Keep whatever `data` was already loaded (if any) so a failed
         // refresh/period-switch doesn't wipe a previously good render —
         // App.tsx shows it dimmed with an inline error, not a blank state.

--- a/web/src/hooks/useProjections.ts
+++ b/web/src/hooks/useProjections.ts
@@ -15,6 +15,32 @@ interface State {
   error: string | null
 }
 
+// Once-per-window reload guard for VITE_AUTH_RELOAD. sessionStorage can throw
+// (private modes / disabled storage), so every access is defensive; a failure
+// degrades to "allow the reload" (the pre-guard behavior), never a crash.
+const RELOAD_MARK = 'ff3e:last-auth-reload'
+const RELOAD_MIN_MS = 10_000
+
+function shouldReloadForAuth(): boolean {
+  try {
+    const now = Date.now()
+    const last = Number(sessionStorage.getItem(RELOAD_MARK) || '0')
+    if (now - last < RELOAD_MIN_MS) return false // reloaded just now → don't loop
+    sessionStorage.setItem(RELOAD_MARK, String(now))
+    return true
+  } catch {
+    return true
+  }
+}
+
+function clearReloadMark(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_MARK)
+  } catch {
+    /* ignore */
+  }
+}
+
 /** Fetches once per (granularity, start, end) — never on a filter change, since
  * filtering happens entirely in the browser. */
 export function useProjections(query: Query) {
@@ -26,7 +52,10 @@ export function useProjections(query: Query) {
     setState((s) => ({ ...s, loading: true, error: null }))
     fetchForecast(query)
       .then((data) => {
-        if (!cancelled) setState({ data, loading: false, error: null })
+        if (!cancelled) {
+          clearReloadMark() // a good load clears the once-per-window reload guard
+          setState({ data, loading: false, error: null })
+        }
       })
       .catch((err) => {
         if (cancelled) return
@@ -34,8 +63,15 @@ export function useProjections(query: Query) {
         // page (bouncing through the login) instead of surfacing a retryable
         // error. Never thrown when the flag is off, so this is inert by default.
         if (err instanceof AuthExpiredError) {
-          window.location.reload()
-          return
+          // Guard against an infinite reload loop: a proxy outage (an HTML
+          // 502/503 page, a trailing-slash redirect) can be shape-identical to
+          // an expired session. Reload at most once per window; if the very
+          // next load fails the same way, fall through and surface the error
+          // instead of hammering the server. Cleared on any successful load.
+          if (shouldReloadForAuth()) {
+            window.location.reload()
+            return
+          }
         }
         // Keep whatever `data` was already loaded (if any) so a failed
         // refresh/period-switch doesn't wipe a previously good render —

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,27 @@
 import type { Granularity, ProjectionsResponse } from './types'
 
+// The forecast endpoint. Defaults to the relative `api/forecast` this server
+// exposes; override with VITE_API_BASE at build time when the SPA is mounted
+// under a different path or proxied by another app (e.g. `/projections/data`).
+const ENDPOINT = import.meta.env.VITE_API_BASE || 'api/forecast'
+
+// Opt-in (VITE_AUTH_RELOAD=1) for deployments where the server sits behind an
+// auth proxy (e.g. Cloudflare Access): an expired session answers with a login
+// interstitial or a redirect instead of JSON. When on, that condition is
+// surfaced as AuthExpiredError so the caller can reload to re-authenticate.
+// Off (default) preserves the plain, direct-server behavior.
+const AUTH_RELOAD =
+  import.meta.env.VITE_AUTH_RELOAD === '1' || import.meta.env.VITE_AUTH_RELOAD === 'true'
+
+/** Raised (only when VITE_AUTH_RELOAD is on) when the round-trip comes back as
+ * an auth interstitial rather than the JSON payload. */
+export class AuthExpiredError extends Error {
+  constructor(message = 'Session expired') {
+    super(message)
+    this.name = 'AuthExpiredError'
+  }
+}
+
 export interface FetchForecastParams {
   granularity: Granularity
   start: string // ISO date
@@ -25,8 +47,12 @@ export async function fetchForecast(params: FetchForecastParams): Promise<Projec
 
   let res: Response
   try {
-    res = await fetch(`api/forecast?${qs.toString()}`, {
+    res = await fetch(`${ENDPOINT}?${qs.toString()}`, {
       headers: { Accept: 'application/json' },
+      // `redirect: 'manual'` so a cross-origin auth-proxy 302 → IdP hands back
+      // an opaque-redirect Response we can detect, instead of throwing a
+      // TypeError before we ever see it. Only under AUTH_RELOAD.
+      ...(AUTH_RELOAD ? { redirect: 'manual' as RequestRedirect } : {}),
     })
   } catch (networkErr) {
     // Dev convenience: `npm run dev` with no server running falls back to the
@@ -35,10 +61,25 @@ export async function fetchForecast(params: FetchForecastParams): Promise<Projec
     throw networkErr
   }
 
+  // Auth-proxy interception (session expired): an opaque redirect or a
+  // non-JSON content-type means we got a login page, not the API — reload to
+  // re-authenticate rather than surfacing a retryable error. Real 5xx-with-JSON
+  // errors fall through to the normal error path below.
+  if (AUTH_RELOAD) {
+    if (res.type === 'opaqueredirect') {
+      throw new AuthExpiredError('Redirected — auth session likely expired')
+    }
+    const contentType = res.headers.get('content-type') || ''
+    if (!contentType.includes('application/json')) {
+      throw new AuthExpiredError(`Unexpected content-type: ${contentType || '(none)'}`)
+    }
+  }
+
   let body: unknown
   try {
     body = await res.json()
   } catch {
+    if (AUTH_RELOAD) throw new AuthExpiredError('Response was not valid JSON')
     throw new Error(`Server returned ${res.status} ${res.statusText} (not JSON)`)
   }
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,12 +5,14 @@ import path from 'node:path'
 
 // `base: './'` (relative) so one bundle works whether it's served at a domain
 // root or mounted at a subpath. Output goes to ./dist, which the server picks
-// up (see server/main.py, or WEB_DIST).
+// up (see server/main.py, or WEB_DIST). Override `base` with VITE_BASE when a
+// consumer mounts the SPA under a fixed absolute path (e.g. `/entropy/`) that
+// relative `./` can't resolve for deep-linked routes.
 //
 // The dev proxy lets `npm run dev` talk to a server running on :8000. With no
 // server up, the app falls back to the synthetic fixtures in src/fixtures/.
 export default defineConfig({
-  base: './',
+  base: process.env.VITE_BASE || './',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Why

Follow-up to the OSS extraction (#5): a downstream consumer that mounts Entropy behind its own auth had to **fork the source** to change four things. This externalizes all four as env/build flags so the consumer can run this repo **unmodified** and absorb upstream by config alone. **Every default is preserved** — a direct, standalone deployment behaves exactly as before.

## What

| Surface | Flag | Default | Effect |
|---|---|---|---|
| engine `_get` | `FIREFLY_CF_ACCESS_CLIENT_ID` / `_SECRET` | unset → not sent | adds Cloudflare Access service-token headers to Firefly requests |
| web `api.ts` | `VITE_API_BASE` | `api/forecast` | overrides the forecast endpoint the SPA calls |
| web `api.ts` + `useProjections.ts` | `VITE_AUTH_RELOAD` | off (inert) | detects an expired auth-proxy session (opaque redirect / non-JSON) → `AuthExpiredError` → hook reloads to re-auth |
| web `vite.config.ts` | `VITE_BASE` | `./` | overrides SPA base path for subpath mounts (e.g. `/entropy/`) |

## Verification

- Default `tsc --noEmit` + `vite build` clean; default fetch path/behavior unchanged.
- `VITE_BASE=/entropy/ VITE_API_BASE=/projections/data VITE_AUTH_RELOAD=1 vite build` emits a bundle based at `/entropy/` that calls `/projections/data` with the auth-reload path wired.

Groundwork for 42L-921 (a private app consuming this repo as the single source instead of a drifting copy). No behavioral change for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)