### PR TITLE
fix(forecast): surface flagged (noisy/shared) accounts instead of silently clearing

### DIFF
--- a/server/forecast.py
+++ b/server/forecast.py
@@ -464,10 +464,15 @@ def build_projection(granularity: str = "month",
                 # that also has a monthly commitment). Flag for we-need-to-talk.
                 if (not slug) and len(avail) > len(occ_sorted):
                     flags.append("noisy_account")
-                n = min(len(avail), len(occ_sorted))
-                for d, t in zip(occ_sorted[:n], avail[:n]):
-                    filled[d] = t.get("id")
-                    used.add(id(t))
+                # Only auto-clear when attribution is unambiguous. A flagged account
+                # (shared or noisy) can't be cleanly attributed, so leave its
+                # occurrences OPEN — they surface for we-need-to-talk rather than being
+                # silently marked paid and dropped from the outstanding set.
+                if not flags:
+                    n = min(len(avail), len(occ_sorted))
+                    for d, t in zip(occ_sorted[:n], avail[:n]):
+                        filled[d] = t.get("id")
+                        used.add(id(t))
 
             remaining = _remaining(a, rtype, src, dst, cards, hist_settle, hist_txns, slug)
             for d in occ_sorted:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -90,6 +90,23 @@ def test_fatura_clears_installment_month(monkeypatch):
     assert out["2026-05-09"]["remaining"] == 1
 
 
+def test_noisy_account_surfaces_not_silently_cleared(monkeypatch):
+    """A noisy account (more identifying payments than occurrences, no slug) must NOT
+    be auto-cleared and dropped — its occurrences stay open, flagged, for review."""
+    today = dt.date(2026, 8, 1)
+    recs = [_rec("Housekeeper", "withdrawal", 5, 1100, "Bank", "Maria", "2026-06-05")]
+    txns = [{"id": f"t{i}", "type": "withdrawal", "date": dt.date(2026, 6, 5 + i),
+             "amount": 50.0, "currency": "BRL", "source": "bank", "destination": "MARIA",
+             "description": "pix", "tags": []} for i in range(5)]   # 5 txns > 3 occ
+    _wire(monkeypatch, recs, txns)
+    res = f.build_projection(granularity="month", start=dt.date(2026, 6, 1),
+                             end=dt.date(2026, 8, 31), today=today)
+    out = _outstanding(res)
+    assert out, "flagged commitment must not vanish from the outstanding set"
+    assert all(it.get("flags") == ["noisy_account"] for it in out.values())
+    assert out["2026-06-05"]["status"] == "needs_review"   # not silently 'paid'
+
+
 def test_non_fatura_transfer_does_not_clear(monkeypatch):
     """A transfer that is NOT into the card must not clear an installment month."""
     today = dt.date(2026, 7, 12)


### PR DESCRIPTION
Follow-up to #14. Under the outstanding-only contract, a noisy account (more identifying payments than occurrences, no `cmt` slug) had every occurrence filled by ordered-fill → marked paid → dropped, silently hiding the ambiguity the `noisy_account` flag is meant to surface.

Now a flagged (shared **or** noisy) Mechanism-A commitment is **not** auto-cleared: its occurrences stay open and flagged, so they appear in the outstanding set for we-need-to-talk. Never silently wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWDxZw6DSzizpzjcJrTrqe