### PR TITLE
fix(forecast): bound the earliest cycle, flag unknown cycles per occurrence

### DIFF
--- a/server/forecast.py
+++ b/server/forecast.py
@@ -282,10 +282,24 @@ def _settled_cycles(cycles: list, settlements: list) -> dict:
 
 def _cycle_of(d: dt.date, cycles: list):
     """The cycle a charge dated `d` was billed in — the first that closes on or after
-    it. `None` when the table does not reach that far: unknown, never assumed."""
-    for c in cycles:
-        if c.close >= d:
-            return c
+    it, provided `d` also falls after that cycle opened. `None` when the table does
+    not reach that far: unknown, never assumed.
+
+    The earliest row has no predecessor to open it, so its opening is taken from the
+    spacing to the next row (a month, when it stands alone). Without that bound, the
+    first cycle in the table would swallow every older charge and clear them all the
+    day its fatura is paid.
+    """
+    for i, c in enumerate(cycles):
+        if c.close < d:
+            continue
+        if i:
+            opens = cycles[i - 1].close
+        elif len(cycles) > 1:
+            opens = c.close - (cycles[1].close - c.close)
+        else:
+            opens = c.close - dt.timedelta(days=31)
+        return c if d > opens else None
     return None
 
 
@@ -550,27 +564,26 @@ def build_projection(granularity: str = "month",
             flags: list = []
             if (not is_card) and keycount.get(key, 0) > 1:
                 flags.append("shared_account")   # >1 commitment on one account
-            filled: dict = {}  # occurrence date → matched txn id (None for fatura)
+            filled: dict = {}  # occurrence date → the txn that accounts for it
+            unknown_cycle: set = set()  # occurrences no cycle row covers
 
             if is_card:
                 # Mechanism B — an occurrence belongs to the cycle it was charged in,
                 # and is settled iff that cycle's fatura was paid.
                 mechanism = "fatura"
                 cycles = cards.get(_norm(src)) or []
-                if not cycles:
-                    # No cycle rows for this card: which fatura a charge fell into is
-                    # unknowable, so nothing is cleared and the item is surfaced.
-                    flags.append("cycle_unknown")
-                else:
-                    settled = _settled_cycles(cycles, hist_settle.get(_norm(src), []))
-                    for d in occ_sorted:
-                        c = _cycle_of(d, cycles)
-                        if c is None:
-                            if "cycle_unknown" not in flags:
-                                flags.append("cycle_unknown")
-                        elif c.close in settled:
-                            filled[d] = settled[c.close]
-                            cleared[(_norm(src), c.close)] += amt
+                settled = _settled_cycles(cycles, hist_settle.get(_norm(src), []))
+                for d in occ_sorted:
+                    # No cycle rows, or none covering this date: which fatura the
+                    # charge fell into is unknowable, so it is not cleared and it
+                    # says so. The flag is per occurrence — a series running past
+                    # the end of the table must not cast doubt on its own past.
+                    c = _cycle_of(d, cycles) if cycles else None
+                    if c is None:
+                        unknown_cycle.add(d)
+                    elif c.close in settled:
+                        filled[d] = settled[c.close]
+                        cleared[(_norm(src), c.close)] += amt
             else:
                 # Mechanism A — ordered-fill: each identifying payment (amount- and
                 # date-blind) clears the earliest still-open occurrence, 1:1.
@@ -614,8 +627,9 @@ def build_projection(granularity: str = "month",
                     "matched_txn_id": matched_id, "mechanism": mechanism,
                     "remaining": remaining,
                 }
-                if flags:
-                    item["flags"] = list(flags)
+                item_flags = flags + (["cycle_unknown"] if d in unknown_cycle else [])
+                if item_flags:
+                    item["flags"] = item_flags
                 items.append(item)
 
     # aggregate

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -255,3 +255,34 @@ def test_non_fatura_transfer_does_not_clear(monkeypatch):
                              end=dt.date(2026, 12, 31), today=today)
     out = _outstanding(res)
     assert out["2026-06-09"]["status"] == "needs_review"   # still open
+
+
+def test_first_cycle_does_not_swallow_older_charges(monkeypatch):
+    """The earliest row opens where the spacing to the next says it does. A charge
+    from before that is not in it, and paying that fatura must not clear it."""
+    today = dt.date(2026, 7, 21)
+    recs = [_rec("Parc", "withdrawal", 9, 300, "Itaucard", "", "2026-04-09", nr=4)]
+    cycles = _cycles(("2026-06-02", "2026-06-09"), ("2026-07-02", "2026-07-09"))
+    txns = [_settlement("jun", "2026-06-09", "Itaucard")]
+    _wire(monkeypatch, recs, txns, cards={"Itaucard": cycles})
+    res = f.build_projection(granularity="month", start=dt.date(2026, 4, 1),
+                             end=dt.date(2026, 7, 31), today=today)
+    out = _outstanding(res)
+    assert out["2026-04-09"]["flags"] == ["cycle_unknown"]   # older than the table
+    assert "2026-05-09" not in out                           # opens 03/05 → June cycle
+    assert out["2026-06-09"]["status"] == "needs_review"     # July cycle, unpaid
+
+
+def test_cycle_unknown_is_per_occurrence_not_per_series(monkeypatch):
+    """A series running past the end of the table must not cast doubt on the months
+    the table does cover."""
+    today = dt.date(2026, 9, 30)
+    recs = [_rec("Parc", "withdrawal", 20, 300, "Itaucard", "", "2026-06-20", nr=4)]
+    cycles = _cycles(("2026-06-02", "2026-06-09"), ("2026-07-02", "2026-07-09"))
+    txns = []
+    _wire(monkeypatch, recs, txns, cards={"Itaucard": cycles})
+    res = f.build_projection(granularity="month", start=dt.date(2026, 6, 1),
+                             end=dt.date(2026, 9, 30), today=today)
+    out = _outstanding(res)
+    assert out["2026-06-20"].get("flags") is None            # covered by the table
+    assert out["2026-08-20"]["flags"] == ["cycle_unknown"]   # beyond it


### PR DESCRIPTION
Two faults found running the new model against live data.

**The first row swallowed everything older.** A cycle was the first one closing on or after the charge, with no opening bound, so every charge predating the table fell into the earliest row and would clear the moment that fatura was paid. The earliest row now opens where the spacing to the next row says it does (a month when it stands alone); anything before that is `cycle_unknown`.

**`cycle_unknown` was a property of the series, not the occurrence.** An installment running past the end of the table flagged all of its own months, including the ones the table covers. The flag is now per occurrence.