### PR TITLE
ci(ds): drop DS_SKIP_DIFF — validate CF allow-rule (42L-1137)

### DIFF
--- a/.github/workflows/ds-compliance.yml
+++ b/.github/workflows/ds-compliance.yml
@@ -44,4 +44,3 @@ jobs:
           DS_TOKENS_FILE: "src/ds-tokens.css"
           DS_UI_DIR: "src/components/ui"
           DS_SCAN: "src"
-          DS_SKIP_DIFF: "1"  # CI cannot reach ds.42labs.io registry (Cloudflare 403s runner IPs); skip only the shadcn network diff — tokens + content gates still enforce (42L-1137)


### PR DESCRIPTION
Removes the DS_SKIP_DIFF stopgap now that the Cloudflare WAF allow-rule for ds.42labs.io /r/* /tokens.* is deployed. If the ds gate goes green here, CI can reach the registry and the full primitive-diff is back. 🤖 Generated with [Claude Code](https://claude.com/claude-code)