### PR TITLE
Fix Button missing forwardRef — header filters and period picker were invisible

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -38,20 +38,26 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+// React 18 (not 19): a plain function component can't receive `ref` — Radix
+// needs a real DOM ref on this element whenever it's used as `asChild` under
+// a Trigger/Anchor (Popover, Dialog, ...) to measure and position floating
+// content. Without forwardRef, React silently drops the ref and Radix's
+// Popper has nothing to anchor to — the trigger still fires (state updates,
+// aria-expanded flips) but the floating panel renders with no real position,
+// effectively invisible. Every FacetedFilter (header filter chips) and
+// PeriodPicker popover was broken this way.
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(({ className, variant = "default", size = "default", asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
@@ -59,6 +65,7 @@ function Button({
       {...props}
     />
   )
-}
+})
+Button.displayName = "Button"
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- \`components/ui/button.tsx\`'s \`Button\` was a plain function component, not wrapped in \`React.forwardRef\`. This project is on React 18 (not 19), where a function component genuinely cannot receive a \`ref\`.
- Radix needs a real DOM ref on the trigger element whenever \`Button\` is used as \`asChild\` under a Popover/Dialog \`Trigger\`, to measure and position the floating content. Without the ref, React drops it silently (console warning only) and Radix's Popper has nothing to anchor to — the trigger still fires (\`aria-expanded\` flips, state updates correctly) but the popover renders with no real position, effectively invisible.
- **User-facing impact:** every header filter chip (Type / Category / Asset Account / Currency), the View switch, and the PeriodPicker (date navigator) appeared completely non-functional — clicking them did nothing visible, "almost like they were fake."

## Fix
Wrapped \`Button\` in \`React.forwardRef\`, forwarding the ref to the underlying element (native \`button\` or Radix \`Slot.Root\` when \`asChild\`).

## Test plan
- [x] \`tsc --noEmit && vite build\` clean
- [x] Verified in the browser: the console ref-forwarding warning is gone entirely
- [x] Clicked all four header filters (Type/Category/Asset Account/Currency) — each popover now renders correctly positioned, fully interactive (search, checkboxes)
- [x] Clicked the PeriodPicker (date navigator) — month grid renders correctly positioned
- [x] Confirmed this was broken before the fix: same click, popover state flipped in the accessibility tree but nothing rendered on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)