### PR TITLE
Group facet lists every asset account, not just the current Account selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ restate it.
 
 "Needs review" is the point of the whole thing. Entropy for Firefly III never
 guesses. It marks an occurrence paid by the **account that paid it, not the
-amount** — so a bill whose amount drifts, or that you paid late or in the next
-month, still counts; each real payment clears the earliest still-open occurrence.
+amount** — so a recurring transaction whose amount drifts, or that you paid
+late or in the next month, still counts; each real payment clears the earliest
+still-open occurrence.
 If nothing accounts for an occurrence once its date has passed it says so, and if
 a payment can't be attributed cleanly (a shared or noisy account) it flags it —
 instead of pretending either way.
@@ -61,7 +62,7 @@ they *are* recurrences, and they still clear against the paid billing cycle belo
 
 ### Card billing cycles
 
-A card bill covers the *previous* cycle: charges up to a closing date, paid a
+A card statement covers the *previous* cycle: charges up to a closing date, paid a
 week or so later. So the month a fatura is paid in tells you nothing about which
 charges it covered, and the closing day is the issuer's choice — one real card
 closed on the 10th one month and the 13th the next. Entropy therefore does not

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ flagged `cycle_unknown`. Unknown is reported, never guessed.
 - Filter by type, category, **account** or currency; totals never cross-sum
   currencies. (The account facet lists only your own asset accounts — the
   paying/receiving side — never expense or revenue counterparties.)
-- In the Data view, **Group** collapses whichever selected account(s) you
-  pick into a per-period subtotal (by flow and currency) instead of listing
-  every item — its options are always exactly the current Account
-  selection, and you choose which of those, if any, to group. Accounts left
-  ungrouped keep their normal item rows alongside the subtotals.
+- In the Data view, **Group** collapses whichever asset account(s) you pick
+  into a per-period subtotal (by flow and currency) instead of listing every
+  item — its options are the same account universe as the Account facet, but
+  chosen independently of it. Accounts left ungrouped keep their normal item
+  rows alongside the subtotals.
 
 ## Run it
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,21 +63,12 @@ export default function App() {
     }
   }
 
-  // Data-table-only: which of the selected Account(s) collapse into a
-  // subtotal row per period instead of one row per item. A sub-selection of
-  // `filters.account` — never a bare on/off toggle, since the operator picks
-  // per-account whether to group it. Pruned below whenever an account drops
-  // out of the Account filter, so it can never reference a stale account.
+  // Data-table-only: which asset account(s) collapse into a subtotal row per
+  // period instead of one row per item. Independent of the Account filter —
+  // its options are every asset account in the dataset, not just whatever's
+  // currently selected in Account — so grouping a card, say, doesn't require
+  // also narrowing the item list down to just that card.
   const [groupAccounts, setGroupAccounts] = useState<string[]>([])
-  useEffect(() => {
-    setGroupAccounts((prev) => {
-      const pruned = prev.filter((a) => filters.account.includes(a))
-      // Same length means the filter dropped nothing (it only ever removes,
-      // never reorders) — return the identical reference so React bails out
-      // of the update instead of re-rendering on every unrelated Account edit.
-      return pruned.length === prev.length ? prev : pruned
-    })
-  }, [filters.account])
 
   const cumulative = isCumulativeMode(mode)
 

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -24,10 +24,10 @@ interface NavItem {
 }
 
 // One entry per view. Entropy for Firefly III ships a single view today
-// (Outstanding & upcoming); adding another later is a new row here (+ a router
+// (Outstanding & Upcoming); adding another later is a new row here (+ a router
 // when there's more than one). The nav LABEL is the only place the view is
 // named — the header bar deliberately carries no title.
-const NAV: NavItem[] = [{ key: 'forecast', label: 'Outstanding & upcoming', icon: CalendarClock }]
+const NAV: NavItem[] = [{ key: 'forecast', label: 'Outstanding & Upcoming', icon: CalendarClock }]
 
 export function AppSidebar({ activeView = 'forecast' }: { activeView?: string }) {
   return (

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -16,17 +16,17 @@ export interface FilterBarProps {
   options: FilterOptions
   filters: ActiveFilters
   onChange: (filters: ActiveFilters) => void
-  /** Data-table-only: which of the selected Account(s) to collapse into a
-   * subtotal row per period instead of one row per item. A multi-select
-   * whose OPTIONS are exactly the current Account selection — it can never
-   * offer an account that isn't also in `filters.account`. */
+  /** Data-table-only: which asset account(s) to collapse into a subtotal row
+   * per period instead of one row per item. A multi-select whose OPTIONS are
+   * every asset account in the dataset (same universe as Account) —
+   * independent of what's currently selected in Account. */
   groupAccounts: string[]
   onGroupAccountsChange: (accounts: string[]) => void
 }
 
-/** The four data facets (+ Group, a fifth facet scoped to whatever Account
- * has selected). Lives in the header (not the page body) so it costs no
- * vertical space. */
+/** The four data facets (+ Group, a fifth facet over the same account
+ * universe as Account, independently selected). Lives in the header (not the
+ * page body) so it costs no vertical space. */
 export function FilterBar({
   options,
   filters,
@@ -74,7 +74,7 @@ export function FilterBar({
       />
       <FacetedFilter
         title="Group"
-        options={filters.account.map((a) => ({ value: a, label: a }))}
+        options={options.accounts.map((a) => ({ value: a, label: a }))}
         selected={groupAccounts}
         onChange={onGroupAccountsChange}
       />

--- a/web/src/components/PeriodTable.tsx
+++ b/web/src/components/PeriodTable.tsx
@@ -42,10 +42,10 @@ function isFullyGrouped(item: ProjectionItem, groupAccounts: string[]): boolean 
 
 export interface PeriodTableProps {
   periods: Period[]
-  /** Which of the selected Account(s) to collapse into a subtotal row per
-   * period instead of one row per item. A sub-selection of the Account
-   * filter — items touching an account outside this list keep their normal
-   * item row alongside any subtotal rows. */
+  /** Which asset account(s) to collapse into a subtotal row per period
+   * instead of one row per item — independent of the Account filter. Items
+   * touching an account outside this list keep their normal item row
+   * alongside any subtotal rows. */
   groupAccounts?: string[]
 }
 


### PR DESCRIPTION
## Summary
- Design bug found by the operator after shipping #24: **Group** was scoped to `filters.account` — its options were exactly whatever the Account facet had selected, so grouping an account required also narrowing Account down to it.
- Decoupled: Group's options are now `options.accounts` (the same full asset-account universe Account itself lists), chosen independently of the Account filter.
- Removed the now-unneeded pruning effect in `App.tsx` (`groupAccounts` no longer needs to be a subset of `filters.account`).
- Also: capitalized "Upcoming" in the sidebar view label — "Outstanding & Upcoming".

## Test plan
- [x] `tsc --noEmit` clean
- [x] Local (demo fixtures): Group lists all 3 asset accounts with no Account filter active; selecting "Rewards Card" in Group alone (Account untouched) correctly produces per-period subtotal rows
- [x] Local (demo fixtures): sidebar label reads "Outstanding & Upcoming"
- [x] CI green