### PR TITLE
An overdue card installment is needs_review, not upcoming

### DIFF
--- a/server/forecast.py
+++ b/server/forecast.py
@@ -697,11 +697,20 @@ def _card_installments(txns: list, cards: dict, today: dt.date,
                     flag = "cycle_projected"
                 if not (start <= d <= end):
                     continue
+                # Same rule the recurrence path applies below (`elif d < today:
+                # needs_review`): a projected tail installment whose date has
+                # already passed, with nothing accounting for it, is NOT "nothing
+                # to do yet" — it is exactly what this project defines as
+                # needs_review. Hardcoding "upcoming" here regardless of `d` was
+                # the one place that contract was broken: a genuinely overdue
+                # installment reported the same status as one due next month, so
+                # nothing keying off status could tell them apart.
+                status = "needs_review" if d < today else "upcoming"
                 item = {
                     "date": d.isoformat(), "title": _clean_title(p["description"]),
                     "type": "withdrawal", "amount": p["amount"], "currency": cur,
                     "source": psrc, "destination": None, "category": cat,
-                    "status": "upcoming", "matched_txn_id": None, "mechanism": "fatura",
+                    "status": status, "matched_txn_id": None, "mechanism": "fatura",
                     "remaining": remaining, "installment_no": n + k,
                     "installment_total": m,
                 }

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -956,3 +956,27 @@ def test_transactions_are_sorted_by_date_then_description(monkeypatch):
     monkeypatch.setattr(f, "fetch_transactions", lambda s, e: rows)
     res = f.build_transactions(dt.date(2026, 7, 1), dt.date(2026, 7, 31))
     assert [t["description"] for t in res["transactions"]] == ["middle", "alpha", "zebra"]
+
+
+def test_derived_installment_past_due_date_is_needs_review(monkeypatch):
+    """A finite installment's projected tail date can itself fall in the past (the
+    statement closed, but nothing has settled it yet). The contract this project
+    states — a passed date with nothing accounting for it is `needs_review` — has
+    to hold here too, identically to the recurrence path's `elif d < today` rule.
+
+    Hardcoding "upcoming" regardless of `d` was the one place it did not: a
+    genuinely overdue installment reported the same status as one due next month,
+    so nothing keying off status could tell them apart. Found downstream, where a
+    consumer had patched its vendored copy rather than this one."""
+    today = dt.date(2026, 8, 15)
+    charges = [_charge("2026-06-02", 9, 12, amount=100.0)]
+    _wire(monkeypatch, [], charges, cards={"Itaucard": _cyc4()})
+    res = f.build_projection(granularity="month", start=dt.date(2026, 1, 1),
+                             end=dt.date(2026, 12, 31), today=today)
+    out = _outstanding(res)
+    assert out["2026-07-02"]["status"] == "needs_review"   # past due (today is 08-15)
+    assert out["2026-08-02"]["status"] == "needs_review"   # past due (08-02 < 08-15)
+    assert out["2026-09-02"]["status"] == "upcoming"       # still ahead
+    # nothing else about the projection changes
+    assert out["2026-09-02"]["installment_no"] == 12
+    assert out["2026-08-02"]["mechanism"] == "fatura"


### PR DESCRIPTION
## The bug

The derived-installment path (Mechanism B) hardcoded `"status": "upcoming"` for every projected tail parcela, whatever its date — `server/forecast.py:704`. So an installment whose statement closed weeks ago, with nothing settling it, reported the **same status** as one due next month. Nothing keying off status could tell them apart.

That contradicts two things at once:

- **This project's own README:** *"Needs review — its date has passed and no payment accounts for it."*
- **The recurrence path six lines further down**, which applies exactly that rule: `elif d < today: status = "needs_review"`.

It was the single place the engine disagreed with itself.

## How it surfaced

Found **downstream**. A consumer vendoring this repo by `git subtree` had patched *its own copy* rather than sending the fix here — so the vendor had quietly become a fork on one line, and the next `subtree pull` would have reverted it silently, in a live financial tool. That pull is what surfaced it.

Fixing it here means it flows back down and the vendor un-forks itself.

## The fix

```python
status = "needs_review" if d < today else "upcoming"
```

Nothing else about the projection changes — date, amount, `installment_no`, `mechanism`, flags all unaffected.

## Verification

- Ported the downstream test. **Verified both ways**: it fails against the old line, passes against the new one — not assumed.
- 58/58 tests (57 + this one)
- `npm run build` green; DS compliance **PASS**
- No README change needed: the code was violating the contract the README already states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)