### PR TITLE
Drop a node_modules symlink committed in #30

### DIFF
--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-../../../ff3e-app/web/node_modules


### PR DESCRIPTION
## What happened

Mine, in #30. I symlink `web/node_modules` at a sibling checkout so a fresh worktree can typecheck without a second `npm install`, and on the **last** commit of that PR I did not remove it before `git add -A`.

It landed on `main` as a mode `120000` blob pointing at `../../../ff3e-app/web/node_modules` — a path that exists on exactly one machine. A fresh clone gets a dangling symlink that escapes the repo root.

CI did not catch it. The Pages build runs its own install over the top, so `0af8f7c` deployed fine and the live demo is correct.

## Why the ignore rule missed it

Both `.gitignore` files said `node_modules/`. The trailing slash means *a directory of that name* — a symlink is not a directory, so nothing matched. Dropping the slash matches both.

Verified: with the fix applied, re-creating the exact same symlink leaves `git status` clean and `git check-ignore -v web/node_modules` reports `web/.gitignore:3:node_modules`.

## Checks

`tsc --noEmit` clean · `npm run build` clean. No source change — one deleted symlink and one character off each ignore file.