### PR TITLE
Actually harden .gitignore against a node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-node_modules/
+node_modules
 dist/
 __pycache__/
 *.pyc

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,6 +1,6 @@
 # dist/ is a build artifact (`npm run build`) — not committed. The server
 # picks it up from web/dist, or from wherever WEB_DIST points.
-node_modules/
+node_modules
 dist/
 .DS_Store
 *.local


### PR DESCRIPTION
## Correction

This is the half of #31 that I claimed had landed and had not.

In #31 I edited both `.gitignore` files and ran `git rm` on the symlink, then committed **without staging the edits** — `git rm` stages by itself, the `sed` did not, and I read the ` M` in `git status` as staged. So #31 removed the symlink (that part is real and verified: `main` has no `node_modules` blob) but shipped none of the rule that would stop the next one.

## The change

`node_modules/` — trailing slash — means *a directory of that name*. A symlink is not a directory, which is exactly why nothing matched the one I committed in #30. Dropping the slash matches both.

Two characters, two files.

## Verification

Run **on this branch with the change staged**, not on an unstaged working tree — which is the mistake being corrected:

```
$ ln -sfn ../../../ff3e-app/web/node_modules web/node_modules
$ git status --short
M  .gitignore
M  web/.gitignore
$ git check-ignore -v web/node_modules
web/.gitignore:3:node_modules	web/node_modules
```

The symlink no longer appears as untracked.