### PR TITLE
docs(readme): align the License section with the org-wide form

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ subpath) purely via build-time flags — no fork needed. Set these when running 
 ## License
 
 Open source — [AGPL-3.0](LICENSE). Commercial — contact ahoy@42labs.io.
-Both, in full: [LICENSING.md](LICENSING.md).
 
 ---
 Built by [42labs](https://github.com/4242labs). Not affiliated with


### PR DESCRIPTION
Drops the `Both, in full: [LICENSING.md](LICENSING.md).` line from the README's `## License` section, so it matches the canonical form used across every 4242labs public repo.

The file layout is untouched — `LICENSE` still holds the verbatim AGPL-3.0 and `LICENSING.md` still holds the dual-licensing terms. Only the README copy changes.

Part of an org-wide pass to bring every public repo to the same LICENSE / About / topics shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)