### PR TITLE
chore(ds): bump to design system 0.9.0 + full compliance sweep

### DIFF
--- a/.github/workflows/ds-compliance.yml
+++ b/.github/workflows/ds-compliance.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 4242labs/design-system
-          ref: v0.6.2 # namespace-aware Gate-3 fix (MEMO-DS-BUMP-0.6.2)
+          ref: 91346ebec48037b780265a2c43ba092970dae5ef # gate reads the registry from this checkout
           token: ${{ secrets.DS_ACTION_TOKEN }} # org secret: a Contents:read PAT
           path: web/.ds-action
 
@@ -40,8 +40,7 @@ jobs:
       - name: DS compliance — tokens, primitives, own-code drift
         run: node .ds-action/.github/actions/ds-compliance/consumer-check.mjs
         env:
-          DS_TOKENS_PIN: "0.7.0"
+          DS_TOKENS_PIN: "0.9.0"
           DS_TOKENS_FILE: "src/ds-tokens.css"
           DS_UI_DIR: "src/components/ui"
           DS_SCAN: "src"
-          DS_SKIP_DIFF: "1"  # CI cannot reach ds.42labs.io registry (Cloudflare 403s runner IPs); skip only the shadcn network diff — tokens + content gates still enforce (42L-1137)

--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
   "style": "new-york",
-  "rsc": false,
+  "rsc": true,
   "tsx": true,
   "tailwind": {
     "config": "",

--- a/web/src/bridge.css
+++ b/web/src/bridge.css
@@ -72,10 +72,13 @@
    * resolve to nothing, breaking every border in the app). ds-tokens.css
    * already defines `--border` with exactly the intended value (incl. the
    * `body.theme-dark` override), so no re-declaration is needed here — the
-   * alias is satisfied by omission. `--input` is a distinct name, so
-   * `var(--border)` below reads the token value with no cycle.
+   * alias is satisfied by omission.
+   *
+   * `--input` is the control boundary, not the card edge: WCAG 1.4.11 wants
+   * 3:1 for the visual information identifying a UI component, which `--border`
+   * does not reach. Since 0.9.0 the DS ships that as its own token.
    */
-  --input: var(--border);
+  --input: var(--border-control);
   --ring: var(--accent-focus);
 
   --radius: var(--r-3);
@@ -133,7 +136,7 @@ body.theme-dark {
   --destructive: var(--red);
   --destructive-foreground: var(--warm-0);
 
-  --input: var(--border);
+  --input: var(--border-control);
   --ring: var(--accent-focus);
 
   --sidebar: var(--surface-alt);

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -12,8 +12,11 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+        // DS theming: border-input (= border-control) on BOTH modes. Upstream
+        // uses --border on light and --input on dark; that asymmetry left the
+        // light outline at 1.38:1 while dark cleared 3:1 for the same control.
         outline:
-          "border bg-background shadow-xs hover:bg-muted hover:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border border-input bg-background shadow-xs hover:bg-muted hover:text-foreground dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
@@ -38,26 +41,20 @@ const buttonVariants = cva(
   }
 )
 
-// React 18 (not 19): a plain function component can't receive `ref` — Radix
-// needs a real DOM ref on this element whenever it's used as `asChild` under
-// a Trigger/Anchor (Popover, Dialog, ...) to measure and position floating
-// content. Without forwardRef, React silently drops the ref and Radix's
-// Popper has nothing to anchor to — the trigger still fires (state updates,
-// aria-expanded flips) but the floating panel renders with no real position,
-// effectively invisible. Every FacetedFilter (header filter chips) and
-// PeriodPicker popover was broken this way.
-const Button = React.forwardRef<
-  HTMLButtonElement,
-  React.ComponentProps<"button"> &
-    VariantProps<typeof buttonVariants> & {
-      asChild?: boolean
-    }
->(({ className, variant = "default", size = "default", asChild = false, ...props }, ref) => {
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
-      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
@@ -65,7 +62,6 @@ const Button = React.forwardRef<
       {...props}
     />
   )
-})
-Button.displayName = "Button"
+}
 
 export { Button, buttonVariants }

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -7,7 +7,9 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        // DS theming: border-subtle, not the inherited --border. Under shadow-sm
+        // (= --elev-1) the border defines the edge; it does not do the separating.
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-border-subtle py-6 shadow-sm",
         className
       )}
       {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,83 +1,192 @@
-import * as React from 'react'
-import * as SelectPrimitive from '@radix-ui/react-select'
-import { Check, ChevronDown } from 'lucide-react'
+"use client"
 
-import { cn } from '@/lib/utils'
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
 
-const Select = SelectPrimitive.Root
-const SelectGroup = SelectPrimitive.Group
-const SelectValue = SelectPrimitive.Value
+import { cn } from "@/lib/utils"
 
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className,
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
       )}
-      position={position}
       {...props}
     >
-      <SelectPrimitive.Viewport
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
         className={cn(
-          'p-1',
-          position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+          // DS theming: border-border-subtle — under shadow-md (= --elev-2) the
+        // popover edge defines, it does not separate.
+        "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border-subtle bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
         )}
+        position={position}
+        align={align}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
 
-export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectItem }
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/web/src/components/ui/separator.tsx
+++ b/web/src/components/ui/separator.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
 

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as SheetPrimitive } from "radix-ui"
@@ -58,7 +60,9 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          // DS theming: border-border-subtle — shadow-lg (= --elev-3) already
+          // carries the separation, so the single edge only defines it.
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg border-border-subtle transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
           side === "right" &&
             "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -244,7 +244,11 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+          // DS theming: the floating variant is an elevated card, so its edge is
+          // border-subtle, not --sidebar-border. The default (flush) variant keeps
+          // --sidebar-border — flush against the canvas it is a divider, not a card
+          // edge, and a divider still has to do the separating on its own.
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-border-subtle group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,72 +1,116 @@
-import * as React from 'react'
+"use client"
 
-import { cn } from '@/lib/utils'
+import * as React from "react"
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
     </div>
-  ),
-)
-Table.displayName = 'Table'
+  )
+}
 
-const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />,
-)
-TableHeader.displayName = 'TableHeader'
-
-const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => (
-    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
-  ),
-)
-TableBody.displayName = 'TableBody'
-
-const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => (
-    <tfoot ref={ref} className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)} {...props} />
-  ),
-)
-TableFooter.displayName = 'TableFooter'
-
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
-  ({ className, ...props }, ref) => (
-    <tr
-      ref={ref}
-      className={cn('border-b border-border transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
       {...props}
     />
-  ),
-)
-TableRow.displayName = 'TableRow'
+  )
+}
 
-const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
-  ({ className, ...props }, ref) => (
-    <th
-      ref={ref}
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
       className={cn(
-        'h-10 px-3 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
-        className,
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
       )}
       {...props}
     />
-  ),
-)
-TableHead.displayName = 'TableHead'
+  )
+}
 
-const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
-  ({ className, ...props }, ref) => (
-    <td ref={ref} className={cn('p-3 align-middle [&:has([role=checkbox])]:pr-0', className)} {...props} />
-  ),
-)
-TableCell.displayName = 'TableCell'
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
-  ({ className, ...props }, ref) => (
-    <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
-  ),
-)
-TableCaption.displayName = 'TableCaption'
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 

--- a/web/src/ds-tokens.css
+++ b/web/src/ds-tokens.css
@@ -1,7 +1,7 @@
 /*
  * 42labs Design System — tokens.css (auto-generated; DO NOT EDIT).
- * Version 0.7.0 · commit 076a6e3 · source-touched 2026-07-14T12:49:30-03:00
- * Source: https://github.com/4242labs/design-system/blob/076a6e3/src/app/globals.css
+ * Version 0.9.0 · commit 8da0b11 · source-touched 2026-08-17T16:07:38-03:00
+ * Source: https://github.com/4242labs/design-system/blob/8da0b11/src/app/globals.css
  * Contains layers 1-3 of globals.css (raw palette + semantic + scale).
  * Layer 4 (@theme inline Tailwind bridge) and layer 5 (layout primitives) are NOT included.
  */
@@ -42,6 +42,7 @@
   --warm-910: #1E1A15;
   --warm-950: #14110D;
   --warm-975: #100D09;
+  --gray-150: #F1F1F0;
   --ink-175: #F0F3F5;
   --ink-400: #C3CDD6;
   --ink-500: #94A2AD;
@@ -91,6 +92,10 @@
   --r-3: 8px;
   --r-4: 10px;
   --r-full: 999px;
+  --elev-0: 0 1px 2px rgb(25 21 16 / 0.05);
+  --elev-1: 0 1px 3px rgb(25 21 16 / 0.06), 0 4px 8px rgb(25 21 16 / 0.04);
+  --elev-2: 0 2px 6px rgb(25 21 16 / 0.07), 0 8px 24px rgb(25 21 16 / 0.06);
+  --elev-3: 0 4px 12px rgb(25 21 16 / 0.08), 0 16px 48px rgb(25 21 16 / 0.10);
   --pad-card: 24px;
   --pad-x: clamp(20px, 5vw, 32px);
   --w-sm: 640px;
@@ -100,10 +105,13 @@
   --bp-sm: 640px;
   --bp-md: 768px;
   --bp-lg: 1024px;
-  --surface: var(--warm-50);
+  --surface: var(--warm-0);
   --surface-alt: var(--warm-0);
   --surface-muted: var(--warm-150);
+  --surface-subtle: var(--gray-150);
   --border: var(--warm-300);
+  --border-subtle: var(--warm-200);
+  --border-control: var(--warm-500);
   --fg: var(--warm-900);
   --fg-2: var(--warm-700);
   --fg-muted: var(--warm-600);
@@ -119,6 +127,7 @@
   --link: var(--orange-700);
   --link-hover: var(--orange-800);
   --logo: var(--orange-700);
+  --logo-word: var(--ink-950);
   --inverse-fg: var(--ink-175);
   --inverse-fg-muted: var(--ink-500);
   --inverse-accent: var(--mint-300);
@@ -128,7 +137,10 @@ body.theme-dark {
   --surface: var(--ink-950);
   --surface-alt: var(--ink-910);
   --surface-muted: var(--ink-820);
+  --surface-subtle: var(--ink-910);
   --border: var(--ink-800);
+  --border-subtle: var(--ink-850);
+  --border-control: var(--ink-600);
   --fg: var(--ink-175);
   --fg-2: var(--ink-400);
   --fg-muted: var(--ink-500);
@@ -144,6 +156,7 @@ body.theme-dark {
   --link: var(--mint-300);
   --link-hover: var(--mint-500);
   --logo: var(--mint-300);
+  --logo-word: var(--warm-50);
   --inverse-fg: var(--warm-900);
   --inverse-fg-muted: var(--warm-600);
   --inverse-accent: var(--orange-700);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,6 +15,28 @@
 @custom-variant dark (&:is(body.theme-dark, body.theme-dark *));
 
 @theme inline {
+  /* DS semantic names, exposed as utilities under their own token names. The
+     registry primitives are written against these (the vendored sidebar paints
+     `bg-surface`), so they must resolve or those components render unpainted. */
+  --color-surface: var(--surface);
+  --color-surface-alt: var(--surface-alt);
+  --color-surface-muted: var(--surface-muted);
+  --color-surface-subtle: var(--surface-subtle);
+  --color-border-subtle: var(--border-subtle);
+  --color-border-control: var(--border-control);
+  --color-fg: var(--fg);
+  --color-fg-2: var(--fg-2);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-disabled: var(--fg-disabled);
+  --color-accent-solid: var(--accent-solid);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-border: var(--accent-border);
+  --color-accent-on: var(--accent-on);
+  --color-logo: var(--logo);
+  --color-logo-word: var(--logo-word);
+  --color-link: var(--link);
+  --color-link-hover: var(--link-hover);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
 
@@ -57,9 +79,27 @@
   --font-heading: var(--font-heading);
   --font-mono: var(--font-mono);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
+  /* The DS names its radius rungs by step and stops at --r-4 (10px); there is
+     no canon rung below 6px or above 10px. Tailwind's xs/xl utilities are used
+     by vendored primitives, so they are clamped to the nearest canon rung
+     rather than left on Tailwind's own defaults (2px / 12px) — which would be
+     a silent fork of the scale. */
+  --radius-xs: var(--r-2);
+  --radius-sm: var(--r-2);
+  --radius-md: var(--r-3);
+  --radius-lg: var(--r-4);
+  --radius-xl: var(--r-4);
+  --radius-full: var(--r-full);
+
+  /* Tailwind owns the --shadow-* namespace, so the DS publishes its elevation
+     rungs as --elev-*; pin them here and every primitive already writing
+     shadow-sm inherits DS elevation with no component edit. Mandatory since
+     0.9.0: --surface-alt now equals --surface (both --warm-0), so a card is
+     told apart from the page by its border and shadow alone. */
+  --shadow-xs: var(--elev-0);
+  --shadow-sm: var(--elev-1);
+  --shadow-md: var(--elev-2);
+  --shadow-lg: var(--elev-3);
 
   --animate-pulse-skeleton: pulse-skeleton 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
Re-vendors tokens at 0.9.0 (0.7.0 -> 0.9.0 is purely additive) and closes
every gap the bump exposes, so the app is DS-compliant end to end rather
than merely pinned.

- The page ground turns white: 0.9.0 resolves --surface to --warm-0, and
  --surface-alt with it, so a card is now told apart from the canvas by its
  border and shadow alone. That makes the elevation pin mandatory: Tailwind
  owns the --shadow-* namespace, so the DS publishes its rungs as --elev-*
  and index.css pins the four of them. Every primitive already writing
  shadow-sm inherits DS elevation with no component edit.
- The DS semantic names are exposed as utilities. The registry sidebar
  paints `bg-surface`, which resolved to nothing here — the app only ever
  mapped the shadcn aliases, never the token names behind them.
- Control boundaries move to --border-control (new in 0.9.0). WCAG 1.4.11
  wants 3:1 for the visual information identifying a UI component, which the
  card-edge --border does not reach.
- The radius scale stops guessing. The canon has rungs at 6/8/10px and
  nothing outside that; xs and xl were falling through to Tailwind's own
  defaults (2px/12px), a silent fork. Both are clamped to the nearest rung,
  and sm/md/lg are aliased to --r-2/3/4 instead of being derived by calc().
- The 11 registry primitives are re-adopted at 0.9.0. components.json flips
  rsc to true so the CLI stops stripping "use client" from registry sources
  on write — the stripping is what made three of them read as edited. The
  directive is inert in a Vite build.

The compliance gate drops its two escape hatches: it reads the tokens and
the registry from the design-system checkout now (4242labs/design-system#90),
so DS_SKIP_DIFF is gone and Gate 3 diffs for real. Pin moves to 0.9.0.

Validated in Chrome DevTools MCP at 1440x900 and 390x844, both views and
both grounds: white ground, mint mark on ink, no console output.