### PR TITLE
docs(readme): refresh contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ subpath) purely via build-time flags — no fork needed. Set these when running 
 ## Contributors
 
 <!-- contributors:start -->
+<a href="https://github.com/42piratas" title="42piratas"><img src="https://avatars.githubusercontent.com/u/18232600?v=4&s=64" width="64" height="64" alt="42piratas" /></a>
 <!-- contributors:end -->
 
 ## License


### PR DESCRIPTION
Contributor list changed. Block regenerated between the README markers by `.github/workflows/contributors.yml` — no hand edits.